### PR TITLE
Show Settings screen when Play Again button is clicked

### DIFF
--- a/src/components/ResultsScreen/index.tsx
+++ b/src/components/ResultsScreen/index.tsx
@@ -3,7 +3,8 @@ import Button from '../Button';
 import styles from './ResultsScreen.module.css';
 
 export default function ResultsScreen() {
-  const { questions, correctAnswers, points, totalPossiblePoints } = useQuiz();
+  const { questions, correctAnswers, points, totalPossiblePoints, dispatch } =
+    useQuiz();
   const totalAnswers = questions.length;
   const correctAnswersPercent = Math.round(
     (correctAnswers / totalAnswers) * 100,
@@ -30,7 +31,9 @@ export default function ResultsScreen() {
 
       <Button
         onClick={function () {
-          return;
+          if (dispatch) {
+            dispatch({ type: 'playAgain' });
+          }
         }}
       >
         Play Again

--- a/src/contexts/QuizContext.tsx
+++ b/src/contexts/QuizContext.tsx
@@ -145,6 +145,10 @@ type QuizActionFinishQuiz = {
   type: 'finishQuiz';
 };
 
+type QuizActionPlayAgain = {
+  type: 'playAgain';
+};
+
 type QuizAction =
   | QuizActionShowSettings
   | QuizActionSettingsSaveName
@@ -156,7 +160,8 @@ type QuizAction =
   | QuizActionDataFailed
   | QuizActionNewAnswer
   | QuizActionNextQuestion
-  | QuizActionFinishQuiz;
+  | QuizActionFinishQuiz
+  | QuizActionPlayAgain;
 
 const initialState: QuizState = {
   status: 'inactive',
@@ -273,6 +278,18 @@ function quizReducer(state: QuizState, action: QuizAction): QuizState {
         status: 'finished',
       };
     }
+    case 'playAgain':
+      return {
+        ...state,
+        status: 'showSettings',
+        questions: [],
+        currentQuestionIndex: 0,
+        selectedAnswer: '',
+        correctAnswers: 0,
+        points: 0,
+        totalPossiblePoints: 100,
+        error: '',
+      };
     default:
       return state;
   }


### PR DESCRIPTION
When the `Play Again` button on the `Results` screen is clicked, the `Settings` screen is shown again. All settings from the previous game are pre-loaded.