### PR TITLE
Decode HTML entities in questions and answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "trivia-quiz-time",
       "version": "0.0.0",
       "dependencies": {
+        "html-entities": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3278,6 +3279,21 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "html-entities": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -3,6 +3,7 @@ import styles from './Question.module.css';
 
 import { shuffleArray } from '../utils/arrayUtils';
 import { useMemo } from 'react';
+import { decode } from 'html-entities';
 
 export default function Question() {
   const { questions, currentQuestionIndex, selectedAnswer, dispatch } =
@@ -32,7 +33,7 @@ export default function Question() {
         <p>{currentQuestion?.category}</p>
         <p>{currentQuestion?.difficulty}</p>
       </header>
-      <p className={styles.questionText}>{currentQuestion?.question}</p>
+      <p className={styles.questionText}>{decode(currentQuestion?.question)}</p>
       <ul className={styles.answerOptions}>
         {shuffledAnswers?.map((answer) => (
           <li key={answer}>
@@ -57,7 +58,7 @@ export default function Question() {
                 }
               }}
             >
-              {answer}
+              {decode(answer)}
             </button>
           </li>
         ))}


### PR DESCRIPTION
Data returned from the API contains HTML entities instead of some characters, and they were not displayed correctly. For example, the HTML entity `&quot;` should display a double quote, but that entity's code was displayed instead (e.g. `&quot;` instead of `"`).

I've used the [html-entities](https://www.npmjs.com/package/html-entities) package that contains a `decode` function for decoding HTML entities. 