### PR TITLE
For true/false answers, show answers in order true, false

### DIFF
--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -34,8 +34,10 @@ export default function Question() {
   }, [currentQuestion]);
 
   const shuffledAnswers = useMemo(() => {
-    if (answers) {
+    if (answers && answers.length > 2) {
       return shuffleArray(answers);
+    } else {
+      return ['True', 'False'];
     }
   }, [answers]);
 


### PR DESCRIPTION
If the possible answers to a question are only `true` and `false`, always show them in the order `true`, then `false`, without shuffling them.