### PR TITLE
Hide Your Name input field

### DIFF
--- a/src/components/SettingsForm/SettingsForm.test.tsx
+++ b/src/components/SettingsForm/SettingsForm.test.tsx
@@ -12,7 +12,7 @@ describe('SettingsForm', () => {
       </QuizProvider>,
     );
 
-    expect(screen.getAllByLabelText('Your name')).toBeTruthy();
+    // expect(screen.getAllByLabelText('Your name')).toBeTruthy();
     expect(screen.getAllByLabelText('Number of questions')).toBeTruthy();
     expect(screen.getAllByLabelText('Category')).toBeTruthy();
     expect(screen.getAllByLabelText('Difficulty')).toBeTruthy();

--- a/src/components/SettingsForm/index.tsx
+++ b/src/components/SettingsForm/index.tsx
@@ -8,7 +8,7 @@ import Button from '../Button';
 import styles from './SettingsForm.module.css';
 
 export default function SettingsForm() {
-  const { name, numberOfQuestions, category, difficulty, dispatch } = useQuiz();
+  const { numberOfQuestions, category, difficulty, dispatch } = useQuiz();
 
   return (
     <form
@@ -21,7 +21,7 @@ export default function SettingsForm() {
         }
       }}
     >
-      <div>
+      {/* <div>
         <label htmlFor="name">Your name</label>
         <input
           id="name"
@@ -36,7 +36,7 @@ export default function SettingsForm() {
             }
           }}
         />
-      </div>
+      </div> */}
 
       <div>
         <label htmlFor="questions-quantity">Number of questions</label>

--- a/src/components/SettingsScreen/SettingsScreen.test.tsx
+++ b/src/components/SettingsScreen/SettingsScreen.test.tsx
@@ -12,7 +12,7 @@ describe('SettingsScreen', () => {
       </QuizProvider>,
     );
 
-    expect(screen.getByText('Your name')).toBeTruthy();
+    expect(screen.getByText('Number of questions')).toBeTruthy();
   });
 
   it('displays Start Quiz button', () => {


### PR DESCRIPTION
The `Your Name` input field is commented out, as the user's name is not used anywhere for now. It will be used later when the score page is implemented. That's why it's been commented out, and not removed.